### PR TITLE
Logging Wrapper Added

### DIFF
--- a/DAQ_FW/lib/Log/Log.cpp
+++ b/DAQ_FW/lib/Log/Log.cpp
@@ -1,0 +1,115 @@
+#include "Log.h"
+
+namespace Logger
+{
+
+    static void PrintLevel(Print *_logOutput, int logLevel)
+    {
+        /// Show log description based on log level
+        switch (logLevel)
+        {
+        case 0:
+            _logOutput->print("[SILENT] :");
+            break;
+        case 1:
+            _logOutput->print("[FATAL] :");
+            break;
+        case 2:
+            _logOutput->print("[ERROR] :");
+            break;
+        case 3:
+            _logOutput->print("[WARNING] :");
+            break;
+        case 4:
+            _logOutput->print("[INFO] :");
+            break;
+        case 5:
+            _logOutput->print("[TRACE] :");
+            break;
+        case 6:
+            _logOutput->print("[VERBOSE] :");
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    static void PrintTimestamp(Print *_logOutput) // unedited ArduinoLog timesamp
+    {
+        // Total time
+        const uint32_t msecs = millis();
+        const uint32_t secs = msecs / MSECS_PER_SEC;
+
+        // Time in components
+        const uint32_t MilliSeconds = msecs % MSECS_PER_SEC;
+        const uint32_t Seconds = secs % SECS_PER_MIN;
+        const uint32_t Minutes = (secs / SECS_PER_MIN) % SECS_PER_MIN;
+        const uint32_t Hours = (secs % SECS_PER_DAY) / SECS_PER_HOUR;
+
+        // Time as string
+        char timestamp[20];
+        sprintf(timestamp, "%02d:%02d:%02d.%03d ", Hours, Minutes, Seconds, MilliSeconds);
+        _logOutput->print(timestamp);
+    }
+
+    static void PrintPrefix(Print *_logOutput, int logLevel)
+    {
+        PrintTimestamp(_logOutput);
+        PrintLevel(_logOutput, logLevel);
+    }
+
+    static void PrintSuffix(Print *_logOutput, int logLevel)
+    {
+        _logOutput->print("");
+    }
+
+    // Wrapper function to be called at setup
+    void Start()
+    {
+        Log.setPrefix(PrintPrefix);
+        Log.setSuffix(PrintSuffix);
+        Log.begin(LOG_LEVEL_VERBOSE, &Serial);
+        Log.setShowLevel(false);
+        Log.info("ArduinoLog System Start Success" CR);
+    }
+
+    void Verbose(const char *msg)
+    {
+        Log.verbose(msg, CR);
+    }
+
+    void Trace(const char *msg)
+    {
+        Log.trace(msg, CR);
+    }
+
+    void Info(const char *msg)
+    {
+        Log.info(msg, CR);
+    }
+
+    void Warning(const char *msg)
+    {
+        Log.warning(msg, CR);
+    }
+
+    void Error(const char *msg)
+    {
+        Log.error(msg, CR);
+    }
+
+    void Fatal(const char *msg)
+    {
+        Log.fatal(msg, CR);
+    }
+}
+// #define USE_ESP32 uncomment to remove ArduinoLog usecase
+
+// void Logger::log(LogLevel level, const std::string &message);
+
+// Desired Log Template:
+// TIME [LOG_LEVEL] : LOG INFO STRING
+// 17:20:10:38 [Info] : ArduinoLog System Start Success
+// ESP32Log Template current:
+// I () DAQ: ESP32log System Start Success

--- a/DAQ_FW/lib/Log/Log.h
+++ b/DAQ_FW/lib/Log/Log.h
@@ -1,0 +1,32 @@
+#ifndef LOG_LIB
+#define LOG_LIB
+
+#include <Arduino.h>
+#include "ArduinoLog.h"
+
+#define LOG_LOCAL_LEVEL ESP_LOG_VERBOSE
+#include "esp_log.h"
+
+namespace Logger
+{
+
+    uint32_t constexpr MSECS_PER_SEC = 1000;
+    uint32_t constexpr SECS_PER_MIN = 60;
+    uint32_t constexpr SECS_PER_HOUR = 3600;
+    uint32_t constexpr SECS_PER_DAY = 86400;
+
+    void Start();
+
+    void Verbose(const char *msg);
+
+    void Trace(const char *msg);
+
+    void Info(const char *msg);
+
+    void Warning(const char *msg);
+
+    void Error(const char *msg);
+
+    void Fatal(const char *msg);
+}
+#endif

--- a/DAQ_FW/platformio.ini
+++ b/DAQ_FW/platformio.ini
@@ -12,3 +12,4 @@
 platform = espressif32
 board = esp32dev
 framework = arduino
+lib_deps = thijse/ArduinoLog@^1.1.1


### PR DESCRIPTION
<!-- Example pull request description -->

# Purpose
<!-- Why does this PR exist? What feature does it add to the codebase? -->

A versatile logging wrapper, allowing for the change of logging libraries by only customizing 2 scripts:  _Log.cpp_ and _Log.h_. 
Thus there won't be a need to rewrite code in any other scripts if there is a change to a different logging library. 

Currently using the ArduinoLog library.

## Implementation
<!--  Provide a high level overview of the implementation details -->

Header needs to include _Log.h_ and be using _namespace Logger_.
On device setup, call _Start()_ or _Logger::Start()_ function to initialize the logging system.
The Log level parameter in the _Log.begin()_ function can be changed to set the lowest log level displayed, and filter out messages that are lower level than the parameter. This may also be changed at runtime via _Logging::setLevel()_ function from  the ArduinoLog.

To create a log message use one of the 6 Log level functions with an accompanying message string.

Available Log Levels: Verbose, Trace, Notice, Info, Warning, Error, Fatal.

The input can print variables in the same way as the _printf()_ function.

**Example Code:** 
_Info("Logging System Start Success");_ 
**Will output:**
_17:20:10:38 [Info] : Logging System Start Success_
**Using the format:**
_TIME_FROM_SETUP [LOG_LEVEL] : LOG INPUT STRING_

The Logger namespace has functions in it to initalize the format of the messages, these are called within the Start() method.
They can be modified in order to customize the message format as needed, but are using the ArduinoLog library, other libaries.

Current functions set the prefix (Timestamp, Log Level) and the suffix (currently nothing, can be changed if needed), with the input log string being put in between. 

The timestamp uses the _millis()_ function, which counts time from the startup of the device. It can be changed to a realtime clock timestamp, but may require an outside connection to sync with the local time, or will need to be manually set thorugh code.

## Testing 

<!-- Put any steps for testing this PR; why should we believe this works? -->

To be tested using an ESP32, compiles without errors

## References
<!-- Include any links to external documentation or resources to ensure reviewers are on the page -->
<!-- Include a link to the appropriate issue -->

https://github.com/thijse/Arduino-Log
https://docs.google.com/document/d/1bXmvKOGXHvtMauRjWnox6od5YsSQDtnRrv-VulEEWuo/edit?usp=sharing
https://github.com/orgs/sfuphantom/projects/2?pane=issue&itemId=17585626