### PR TITLE
Iadc sensor

### DIFF
--- a/DAQ_FW/include/system_config.h
+++ b/DAQ_FW/include/system_config.h
@@ -4,6 +4,15 @@
 #include <Arduino.h>
 #include <stdarg.h>
 
+// I2C Addressess for the ADS1115 connection
+enum class ADCAddress
+{
+    U1 = 0x48,
+    U2 = 0x49,
+    U3 = 0x4A,
+    U4 = 0x4B
+};
+
 // DAQ global Log Level Setup Filter
 #define CURRENT_LOG_LEVEL LOG_LEVEL_VERBOSE
 // Options:

--- a/DAQ_FW/include/system_config.h
+++ b/DAQ_FW/include/system_config.h
@@ -15,15 +15,9 @@
 // 5 - LOG_LEVEL_TRACE      errors, warnings, notices & traces
 // 6 - LOG_LEVEL_VERBOSE    all
 
-// PROGRAMMABLE GAIN MODES OF THE ADS1115 ADC
-// TODO: CHANGE VALUES/NAMES ACCORDING TO THE ADC LIBRARY
-// AND TO SYNC WITH THE DRIVER CLASS
-#define GAIN_TWOTHIRDS 0
-#define GAIN_ONE 1
-#define GAIN_TWO 2
-#define GAIN_FOUR 3
-#define GAIN_EIGHT 4
-#define GAIN_SIXTEEN 5
+// Defines global decimal places when displaying floats and doubles ('%D' AND '%F')
+// param goes to ArduinoLog.cpp line 192: _logOutput->print(va_arg(*args, double), LOG_DECIMAL_PLACES);
+#define LOG_DECIMAL_PLACES 5
 
 // Baud Rate variable
 uint32_t constexpr BAUD_RATE = 9600;

--- a/DAQ_FW/lib/IADCSensor/IADCSensor.cpp
+++ b/DAQ_FW/lib/IADCSensor/IADCSensor.cpp
@@ -6,7 +6,7 @@
 // PGA offers input ranges from ±0.256 V to ±6.144 V
 // adc resolution : 65536
 
-// PGA VALUES for a ADS1115 -
+// PGA VALUES for a ADS1115
 // TODO: MOVE TO SYS_CONFIG WHEN FINAL
 #define ADS1115_GAIN_TWOTHIRDS 0.187500f
 #define ADS1115_GAIN_ONE 0.125000f
@@ -18,67 +18,51 @@
 // CLASS METHODS:
 
 // Default constructor with generic metadata
-IADCSensor::IADCSensor(const char *_SensorName, uint16_t _SensorID, uint16_t _ADC_ID, uint16_t _ADC_GAIN_MODE)
-    : mSensorName(_SensorName), mSensorID(_SensorID), mADC_ID(_ADC_ID)
-{
-    initializeVoltagePerBit(_ADC_GAIN_MODE);
+IADCSensor::IADCSensor(const char *_SensorName, uint16_t _SensorID, uint16_t _ADC_ID)
+    : mSensorName(_SensorName), mSensorID(_SensorID), mADC_ID(_ADC_ID) {}
 
-    // obj declared when logger not active, could be hard to log
-    Logger::Notice("Class created with gain mode: %u and V/per bit of %D", _ADC_GAIN_MODE, mVOLTAGE_PER_BIT);
+// ADS1115 initialize func, to be called on setup()
+void IADCSensor::Initialize()
+{
+    if (!mADS.begin(ADS1X15_ADDRESS))
+    {
+        Logger::Error("Failed to start ads");
+        while (1)
+            ;
+    }
+    else
+        Logger::Notice("ADC initialized");
 }
 
-float IADCSensor::Process() const
+float IADCSensor::Process()
 {
-
-    // Random var for testing
-    uint16_t raw_data = Read();
+    // gets bit data from the adc
+    int16_t raw_data = Read();
 
     Logger::Trace("Initial Data: %u from sensor <%s> with ID: %u and ads id %u", raw_data, mSensorName, mSensorID, mADC_ID);
 
     // processing code goes here - to be done for different sensor types
     // converts voltage to sensor data, include warnings, errors
 
-    float final_data = raw_data * mVOLTAGE_PER_BIT;
+    // adc bit to voltage conversion, gain mode can be set via the adc library
+    float final_data = mADS.computeVolts(raw_data);
 
     Logger::Notice("Processed Data: %D, from sensor <%s> with ID: %u and adc id %u", final_data, mSensorName, mSensorID, mADC_ID);
 
     return (float)final_data;
 }
 
-uint16_t IADCSensor::Read() const
+int16_t IADCSensor::Read()
 {
     Logger::Error("Default Read Function Called!");
-    // variable for testing
-    return (uint16_t)5230;
-}
+    // testing read function - NOT FINAL
+    int16_t adc0 = mADS.readADC_SingleEnded(0);
 
-// picks correct Voltage ber bit ration, according to the gain mode
-void IADCSensor::initializeVoltagePerBit(uint16_t _ADC_GAIN_MODE)
-{
-    switch (_ADC_GAIN_MODE)
+    if (!adc0)
     {
-    case GAIN_TWOTHIRDS:
-        mVOLTAGE_PER_BIT = ADS1115_GAIN_TWOTHIRDS;
-        break;
-    case GAIN_ONE:
-        mVOLTAGE_PER_BIT = ADS1115_GAIN_ONE;
-        break;
-    case GAIN_TWO:
-        mVOLTAGE_PER_BIT = ADS1115_GAIN_TWO;
-        break;
-    case GAIN_FOUR:
-        mVOLTAGE_PER_BIT = ADS1115_GAIN_FOUR;
-        break;
-    case GAIN_EIGHT:
-        mVOLTAGE_PER_BIT = ADS1115_GAIN_EIGHT;
-        break;
-    case GAIN_SIXTEEN:
-        mVOLTAGE_PER_BIT = ADS1115_GAIN_SIXTEEN;
-        break;
-
-    default:
-        mVOLTAGE_PER_BIT = 0.0f;
-        Logger::Error("INVALID GAIN OPTION");
-        break;
+        Logger::Warning("No Input Detected");
+        return 0;
     }
+
+    return (int16_t)adc0;
 }

--- a/DAQ_FW/lib/IADCSensor/IADCSensor.cpp
+++ b/DAQ_FW/lib/IADCSensor/IADCSensor.cpp
@@ -35,7 +35,7 @@ void IADCSensor::Initialize()
         Logger::Notice("ADC %s initialized", PrintAddress());
 }
 
-float IADCSensor::Process()
+float IADCSensor::GetData()
 {
     // gets bit data from the adc
     int16_t raw_data = Read();
@@ -43,11 +43,8 @@ float IADCSensor::Process()
     Logger::Trace("Initial Data: %u from sensor <%s> with ID: %u and ads component %s",
                   raw_data, mSensorName, mSensorID, PrintAddress());
 
-    // processing code goes here - to be done for different sensor types
-    // converts voltage to sensor data, include warnings, errors
-
     // adc bit to voltage conversion, gain mode can be set via the adc library
-    float final_data = mADS.computeVolts(raw_data);
+    float final_data = Process(mADS.computeVolts(raw_data)); // Process is overidden by the child class
 
     Logger::Notice("Processed Data: %D, from sensor <%s> with ID: %u and adc component %s",
                    final_data, mSensorName, mSensorID, PrintAddress());
@@ -57,7 +54,7 @@ float IADCSensor::Process()
 
 int16_t IADCSensor::Read()
 {
-    Logger::Error("Default Read Function Called!");
+
     // testing read function - NOT FINAL
     int16_t adcBitData = mADS.readADC_SingleEnded(0);
 
@@ -69,6 +66,12 @@ int16_t IADCSensor::Read()
     }
 
     return (int16_t)adcBitData;
+}
+
+float ChildExample::Process(float InputData)
+{
+    Logger::Error("Using example class");
+    return InputData;
 }
 
 const char *IADCSensor::PrintAddress()

--- a/DAQ_FW/lib/IADCSensor/IADCSensor.cpp
+++ b/DAQ_FW/lib/IADCSensor/IADCSensor.cpp
@@ -26,12 +26,13 @@ void IADCSensor::Initialize()
 {
     if (!mADS.begin(ADS1X15_ADDRESS))
     {
-        Logger::Error("Failed to start ads");
         while (1)
-            ;
+        {
+            Logger::Error("Failed to start ads with ID: %u", mADC_ID);
+        }
     }
     else
-        Logger::Notice("ADC initialized");
+        Logger::Notice("ADC %u initialized", mADC_ID);
 }
 
 float IADCSensor::Process()
@@ -56,13 +57,14 @@ int16_t IADCSensor::Read()
 {
     Logger::Error("Default Read Function Called!");
     // testing read function - NOT FINAL
-    int16_t adc0 = mADS.readADC_SingleEnded(0);
+    int16_t adcBitData = mADS.readADC_SingleEnded(0);
 
-    if (!adc0)
+    if (!adcBitData)
     {
-        Logger::Warning("No Input Detected");
+        Logger::Warning("No Input Detected from sensor <%s> with ID: %u and adc id %u",
+                        mSensorName, mSensorID, mADC_ID);
         return 0;
     }
 
-    return (int16_t)adc0;
+    return (int16_t)adcBitData;
 }

--- a/DAQ_FW/lib/IADCSensor/IADCSensor.h
+++ b/DAQ_FW/lib/IADCSensor/IADCSensor.h
@@ -29,8 +29,8 @@ private:
     // Currently Generic Parameters, to be expanded as needed
     // TODO: add more specific data, depends on the sensors
     const char *mSensorName;
-    uint32_t mSensorID;
-    uint32_t mADC_ID;
+    const uint32_t mSensorID;
+    const uint32_t mADC_ID;
 };
 
 #endif

--- a/DAQ_FW/lib/IADCSensor/IADCSensor.h
+++ b/DAQ_FW/lib/IADCSensor/IADCSensor.h
@@ -9,10 +9,9 @@
 class IADCSensor
 {
 public:
-    IADCSensor(const char *_SensorName, uint16_t _SensorID, uint16_t _ADC_ID);
+    IADCSensor(const char *_SensorName, const uint16_t _SensorID, const ADCAddress _ADCAddress);
 
     // call in setup(), initializes the adc
-    // TODO: may need to be changed as we will have multiple sensors on single adc
     // needs to be hardware tested
     void Initialize();
 
@@ -22,6 +21,9 @@ public:
 
     float Process();
 
+    // for logging the address of the current ADC
+    const char *PrintAddress();
+
 private:
     Adafruit_ADS1115 mADS;
 
@@ -30,7 +32,7 @@ private:
     // TODO: add more specific data, depends on the sensors
     const char *mSensorName;
     const uint32_t mSensorID;
-    const uint32_t mADC_ID;
+    const ADCAddress mADC_Address;
 };
 
 #endif

--- a/DAQ_FW/lib/IADCSensor/IADCSensor.h
+++ b/DAQ_FW/lib/IADCSensor/IADCSensor.h
@@ -15,11 +15,14 @@ public:
     // needs to be hardware tested
     void Initialize();
 
-    // Read function - to be overwritten by the Driver class
-    // When child class is ready, make abstract
-    virtual int16_t Read();
+    // Reads 16 bits of data from the current mADC
+    int16_t Read();
 
-    float Process();
+    float GetData();
+
+    // processing code goes here - to be overwritten for different sensor types
+    // converts voltage to sensor data, include warnings, errors
+    virtual float Process(float inputData) = 0;
 
     // for logging the address of the current ADC
     const char *PrintAddress();
@@ -33,6 +36,15 @@ private:
     const char *mSensorName;
     const uint32_t mSensorID;
     const ADCAddress mADC_Address;
+};
+
+// example implementation of the senor child class
+class ChildExample : public IADCSensor
+{
+public:
+    ChildExample(const char *_SensorName, const uint16_t _SensorID, const ADCAddress _ADCAddress)
+        : IADCSensor(_SensorName, _SensorID, _ADCAddress) {}
+    float Process(float InputData);
 };
 
 #endif

--- a/DAQ_FW/lib/IADCSensor/IADCSensor.h
+++ b/DAQ_FW/lib/IADCSensor/IADCSensor.h
@@ -1,23 +1,29 @@
 #ifndef IADCSENSOR_LIB
 #define IADCSENSOR_LIB
 
+#include <Wire.h>
+#include <Adafruit_ADS1X15.h>
 #include "Logger.h"
 #include "system_config.h"
 
 class IADCSensor
 {
 public:
-    IADCSensor(const char *_SensorName, uint16_t _SensorID, uint16_t _ADC_ID, uint16_t _ADC_GAIN_MODE);
+    IADCSensor(const char *_SensorName, uint16_t _SensorID, uint16_t _ADC_ID);
+
+    // call in setup(), initializes the adc
+    // TODO: may need to be changed as we will have multiple sensors on single adc
+    // needs to be hardware tested
+    void Initialize();
 
     // Read function - to be overwritten by the Driver class
     // When child class is ready, make abstract
-    virtual uint16_t Read() const;
+    virtual int16_t Read();
 
-    float Process() const;
+    float Process();
 
 private:
-    // bit to voltage conversion factor
-    float mVOLTAGE_PER_BIT;
+    Adafruit_ADS1115 mADS;
 
     // SENSOR METADATA:
     // Currently Generic Parameters, to be expanded as needed
@@ -25,8 +31,6 @@ private:
     const char *mSensorName;
     uint32_t mSensorID;
     uint32_t mADC_ID;
-
-    void initializeVoltagePerBit(uint16_t _ADC_GAIN_MODE);
 };
 
 #endif

--- a/DAQ_FW/platformio.ini
+++ b/DAQ_FW/platformio.ini
@@ -12,5 +12,8 @@
 platform = espressif32
 board = esp32dev
 framework = arduino
-lib_deps = thijse/ArduinoLog@^1.1.1
+lib_deps = 
+	thijse/ArduinoLog@^1.1.1
+	adafruit/Adafruit ADS1X15@^2.4.0
+	SPI
 build_flags = -I include

--- a/DAQ_FW/src/main.cpp
+++ b/DAQ_FW/src/main.cpp
@@ -3,8 +3,8 @@
 
 // object declarations can't be done in setup()
 
-// params: sensorname, sensorID, adcID
-IADCSensor SensorTest("TestSensor", 1, 0);
+// params: sensorname, sensorID, adcAddress
+IADCSensor SensorTest("TestSensor", 1, ADCAddress::U1);
 
 void setup()
 {

--- a/DAQ_FW/src/main.cpp
+++ b/DAQ_FW/src/main.cpp
@@ -1,4 +1,3 @@
-
 #include "Logger.h"
 #include "IADCSensor.h"
 

--- a/DAQ_FW/src/main.cpp
+++ b/DAQ_FW/src/main.cpp
@@ -4,20 +4,21 @@
 
 // object declarations can't be done in setup()
 
-// params: sensorname, sensorID, adcID, gainmode
-IADCSensor SensorTest("TestSensor", 1, 1, GAIN_TWO);
+// params: sensorname, sensorID, adcID
+IADCSensor SensorTest("TestSensor", 1, 0);
 
 void setup()
 {
   // put your setup code here, to run once:
   Logger::Start();
   Logger::Notice("Setup");
+
+  SensorTest.Initialize();
 }
 
 void loop()
 {
   // put your main code here, to run repeatedly:
-
   Logger::Notice("Hello World");
 
   SensorTest.Process();

--- a/DAQ_FW/src/main.cpp
+++ b/DAQ_FW/src/main.cpp
@@ -4,7 +4,7 @@
 // object declarations can't be done in setup()
 
 // params: sensorname, sensorID, adcAddress
-IADCSensor SensorTest("TestSensor", 1, ADCAddress::U1);
+ChildExample SensorTest("TestSensor", 1, ADCAddress::U1);
 
 void setup()
 {
@@ -20,7 +20,7 @@ void loop()
   // put your main code here, to run repeatedly:
   Logger::Notice("Hello World");
 
-  SensorTest.Process();
+  SensorTest.GetData();
 
   delay(1000);
 }


### PR DESCRIPTION
<!-- Example pull request description -->

# Purpose
<!-- Why does this PR exist? What feature does it add to the codebase? -->
Implementation of the Adafruit Ads library, allowing for the class to interface with the ADC and receive data from it.


## Implementation
<!--  Provide a high level overview of the implementation details -->

Functions the same as the theoretical implementation, `Read()` returns the binary data from the ADC, and `Process()` uses that value and converts it into Voltage.
An `Initialize()` function was also added, that begins the ads on `setup()`

The adafruitADS11X5 library also allows for gain mode initialization and voltage conversion functions, thus the ones implemented previously became obsolete and were removed.

`Read()` and `Process()` also can not be const anymore, as the mADS library object will be modified with calls to the library functions.

## Testing 

<!-- Put any steps for testing this PR; why should we believe this works? -->

Tested with an ESP32 as well as the ADS1115 - will require further testing with sensors, once they are available.

View on github

## References
<!-- Include any links to external documentation or resources to ensure reviewers are on the page -->
<!-- Include a link to the appropriate issue -->

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#referencing-issues-and-pull-requests

## PR Review Rules 

1. Reviewer is responsible for resolving any threads they started
2. One commit per thread and if it's a widespread change, link the commit in the reply pls :)
3. ...
